### PR TITLE
Removed extraneous navigation config settings.

### DIFF
--- a/homepairs/homepairsUI/src/Routes/Routes.tsx
+++ b/homepairs/homepairsUI/src/Routes/Routes.tsx
@@ -75,12 +75,7 @@ const innerStackConfig: any = {
 
 
 //these should be separated into different files for each Route (AccountProperties, Service Request, Account)
-const propertyStackConfig_PM = {
-  initialRouteName: 'TenantProperties',
-  ...innerStackConfig
-}
-
-const propertyStackConfig_Tenant = {
+const propertyStackConfig = {
   initialRouteName: 'TenantProperties',
   ...innerStackConfig
 }
@@ -99,7 +94,7 @@ const PropertyStack = createStackNavigator({
   AccountProperties: MainAppPages.PropertyPages.PropertiesScreen,
   TenantProperties: MainAppPages.PropertyPages.TenantPropertiesScreen,
   DetailedProperty: MainAppPages.PropertyPages.DetailedPropertyScreen
-}, propertyStackConfig_PM);
+}, propertyStackConfig);
 const ServiceRequestStack = createStackNavigator(
   { ServiceRequest: MainAppPages.ServiceRequestPages.ServiceRequestScreen },
   serviceRequestStackConfig);


### PR DESCRIPTION
Removed extraneous navigation config files and we are now using only 1 config for the property Stack. It also defaults to tenant but we should ALWAYS call the ChooseMainPage instead. 