### PR TITLE
Service request ui update

### DIFF
--- a/homepairs/homepairsUI/npmInstall.sh
+++ b/homepairs/homepairsUI/npmInstall.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#run this whenever you switch branches
+
+cd node_modules/@expo/webpack-config
+npm i --prod webpack@4.39.0
+cd ../../..
+npm install --prod

--- a/homepairs/homepairsUI/res/Styles/base.ts
+++ b/homepairs/homepairsUI/res/Styles/base.ts
@@ -77,7 +77,6 @@ export const MarginPadding = {
 
 export const ContentWidth = {
     almostThird: '27.3333333%',
-    almostHalf: '50%',
     third: '33.3333333%',
     half: '50%',
     thin: '90%',

--- a/homepairs/homepairsUI/res/Styles/base.ts
+++ b/homepairs/homepairsUI/res/Styles/base.ts
@@ -2,16 +2,17 @@ import { HomePairsDimensions } from 'homepairs-types';
 import { HomePairFonts } from '../fonts';
 
 export type ColorTheme = {
-    primary: string
-    secondary: string
-    tertiary: string
-    space: string
-    transparent: string
-    red: string
-    gray: string
+    primary: string,
+    secondary: string,
+    tertiary: string,
+    space: string,
+    transparent: string,
+    red: string,
+    darkGray: string,
+    gray: string,
     lightGray: string,
     veryLightGray: string,
-    shadow: string
+    shadow: string,
     roopairs: string,
 }
 export const LightColorTheme : ColorTheme = {
@@ -21,6 +22,7 @@ export const LightColorTheme : ColorTheme = {
     space: '#1177B0',
     transparent: 'transparent',
     red: '#C70000',
+    darkGray: '#737A7C',
     gray: 'rgba(0,0,0,.5)',
     lightGray: 'rgba(55,66,69,.5)',
     veryLightGray: '#E9ECEF',
@@ -62,6 +64,7 @@ export const MarginPadding = {
     medium: '2.5%',
     inputForm: '3.5%',
     large: '5%',
+    statusButton: '6.0%',
     xlarge: '10%',
 
     xsmallConst: 2.5,
@@ -73,8 +76,8 @@ export const MarginPadding = {
 };
 
 export const ContentWidth = {
-    almostThird: '29.3333333%',
-    almostHalf: '44%',
+    almostThird: '27.3333333%',
+    almostHalf: '50%',
     third: '33.3333333%',
     half: '50%',
     thin: '90%',

--- a/homepairs/homepairsUI/res/strings.tsx
+++ b/homepairs/homepairsUI/res/strings.tsx
@@ -12,8 +12,8 @@ const strings = {
     serviceRequestPage: {
         title: 'Service Requests',
         button: 'New Request',
-        tabA: 'Current Requests',
-        tabB: 'Archived Requests',
+        tabA: 'View Current Requests',
+        tabB: 'View Archived Requests',
         tabA1: 'Pending',
         tabA2: 'Scheduled',
         tabA3: 'In Progress',

--- a/homepairs/homepairsUI/src/components/ServiceRequestCount/ServiceRequestCount.tsx
+++ b/homepairs/homepairsUI/src/components/ServiceRequestCount/ServiceRequestCount.tsx
@@ -33,7 +33,7 @@ type ServiceRequestCountState = {
     inProgress: number;
 };
 
-const intialState: ServiceRequestCountState = {
+const initialState: ServiceRequestCountState = {
     pending: 0,
     scheduled: 0,
     inProgress: 0,
@@ -163,7 +163,7 @@ export default class ServiceRequestCount extends React.Component<ServiceRequestC
 
     constructor(props: Readonly<ServiceRequestCountProps>){
         super(props);
-        this.state = intialState;
+        this.state = initialState;
     }
 
     async componentDidMount(){

--- a/homepairs/homepairsUI/src/elements/Panels/ServiceRequestAddressPanel.tsx
+++ b/homepairs/homepairsUI/src/elements/Panels/ServiceRequestAddressPanel.tsx
@@ -50,7 +50,7 @@ function setStyles() {
             padding: BaseStyles.MarginPadding.large,
             paddingTop: 10,
             paddingBottom: 30,
-            width: BaseStyles.ContentWidth.thin,
+            width: '100%',
             alignSelf: 'center',
             borderColor: '#B3C0C2',
             borderWidth: 1,

--- a/homepairs/homepairsUI/src/screens/Main/ServiceRequest/ServiceRequestScreen/ServiceRequestScreenBase.tsx
+++ b/homepairs/homepairsUI/src/screens/Main/ServiceRequest/ServiceRequestScreen/ServiceRequestScreenBase.tsx
@@ -109,14 +109,14 @@ const styles = StyleSheet.create({
     currentButtonStyle: {
         justifyContent: 'center',
         backgroundColor: colors.transparent,
-        width: BaseStyles.ContentWidth.almostHalf,
+        width: BaseStyles.ContentWidth.half,
         borderColor: colors.darkGray,
         height: 40,
     },
     archivedButtonStyle: {
         justifyContent: 'center',
         backgroundColor: colors.transparent,
-        width: BaseStyles.ContentWidth.almostHalf,
+        width: BaseStyles.ContentWidth.half,
         borderColor: colors.darkGray,
         height: 40,
     },

--- a/homepairs/homepairsUI/src/screens/Main/ServiceRequest/ServiceRequestScreen/ServiceRequestScreenBase.tsx
+++ b/homepairs/homepairsUI/src/screens/Main/ServiceRequest/ServiceRequestScreen/ServiceRequestScreenBase.tsx
@@ -6,7 +6,7 @@ import {
     StyleSheet,
     TouchableOpacity,
 } from 'react-native';
-import { ServiceRequestButton, ServiceRequestAddressPanel, SearchForm} from 'homepairs-elements';
+import { ServiceRequestButton, ServiceRequestAddressPanel, SearchForm } from 'homepairs-elements';
 import {
     HomePairsDimensions,
     ServiceRequest,
@@ -24,6 +24,7 @@ import { SceneInjectedProps } from 'homepairs-components';
 import { NavigationRouteScreenProps, navigationPages, MainAppStack } from 'homepairs-routes';
 import { fetchServiceRequests } from 'homepairs-endpoints';
 import { stringToCategory } from 'homepairs-utilities';
+import { initialState } from 'src/state/preferred-service-provider/reducer';
 
 
 export type ServiceRequestScreenStateProps = {
@@ -39,6 +40,12 @@ export type ServiceRequestsScreenDispatchProps = {
 type ServiceRequestRadioState = {
     currentRequestsSelected: boolean,
     requestSelected: ServiceRequestStatus,
+    pending: number;
+    scheduled: number;
+    inProgress: number;
+    completed: number;
+    canceled: number;
+    declined: number;
 }
 
 type ServiceRequestState = ServiceRequestRadioState & {
@@ -79,8 +86,8 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         justifyContent: 'center',
         flexDirection: 'row',
-        paddingTop: BaseStyles.MarginPadding.xsmallConst,
-        width: BaseStyles.ContentWidth.max,
+        padding: BaseStyles.MarginPadding.mediumConst,
+        width: BaseStyles.ContentWidth.reg,
     },
     titleContainer: {
         alignItems: 'center',
@@ -93,139 +100,110 @@ const styles = StyleSheet.create({
         fontFamily: BaseStyles.FontTheme.primary,
         color: colors.lightGray,
     },
-    selectedLeftButton: {
-        alignItems: 'flex-start',
+    currentArchivedButtonText: {
+        color: colors.darkGray,
+        fontSize: BaseStyles.FontTheme.reg,
+        textDecorationLine: 'underline',
+        alignSelf: 'center',
+    },
+    currentButtonStyle: {
         justifyContent: 'center',
-        backgroundColor: colors.primary,
-        padding: BaseStyles.MarginPadding.mediumConst,
+        backgroundColor: colors.transparent,
         width: BaseStyles.ContentWidth.almostHalf,
-        borderTopLeftRadius: BaseStyles.BorderRadius.small,
-        borderBottomLeftRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
+        borderColor: colors.darkGray,
         height: 40,
     },
-    selectedRightButton: {
-        alignItems: 'flex-end',
+    archivedButtonStyle: {
         justifyContent: 'center',
-        backgroundColor: colors.primary,
-        padding: BaseStyles.MarginPadding.mediumConst,
+        backgroundColor: colors.transparent,
         width: BaseStyles.ContentWidth.almostHalf,
-        borderTopRightRadius: BaseStyles.BorderRadius.small,
-        borderBottomRightRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
+        borderColor: colors.darkGray,
         height: 40,
     },
     selectedLeftThirdButton: {
         alignItems: 'flex-start',
         justifyContent: 'center',
-        backgroundColor: colors.primary,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderTopLeftRadius: BaseStyles.BorderRadius.small,
-        borderBottomLeftRadius: BaseStyles.BorderRadius.small,
         borderBottomWidth: 1,
-        height: 40,
+        borderColor: colors.primary,
+        height: 30,
     },
     selectedMiddleThirdButton: {
         alignItems: 'center',
         justifyContent: 'center',
-        backgroundColor: colors.primary,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
-        height: 40,
+        borderBottomWidth: 1,
+        borderColor: colors.primary,
+        height: 30,
+        marginHorizontal: BaseStyles.MarginPadding.statusButton,
     },
     selectedRightThirdButton: {
         alignItems: 'flex-end',
         justifyContent: 'center',
-        backgroundColor: colors.primary,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderTopRightRadius: BaseStyles.BorderRadius.small,
-        borderBottomRightRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
-        height: 40,
+        borderBottomWidth: 1,
+        borderColor: colors.primary,
+        height: 30,
     },
     selectedText: {
-        color: colors.secondary,
-        fontSize: BaseStyles.FontTheme.reg,
+        color: colors.shadow,
+        fontSize: BaseStyles.FontTheme.small,
+        fontFamily: BaseStyles.FontTheme.secondary,
         alignSelf: 'center',
         justifyContent: 'center',
         alignItems: 'center',
-    },
-    unselectedLeftButton: {
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        backgroundColor: colors.transparent,
-        padding: BaseStyles.MarginPadding.mediumConst,
-        width: BaseStyles.ContentWidth.almostHalf,
-        borderTopLeftRadius: BaseStyles.BorderRadius.small,
-        borderBottomLeftRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
-        height: 40,
-    },
-    unselectedRightButton: {
-        alignItems: 'flex-end',
-        justifyContent: 'center',
-        backgroundColor: colors.transparent,
-        padding: BaseStyles.MarginPadding.mediumConst,
-        width: BaseStyles.ContentWidth.almostHalf,
-        borderTopRightRadius: BaseStyles.BorderRadius.small,
-        borderBottomRightRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
-        borderColor: colors.lightGray,
-        height: 40,
     },
     unselectedLeftThirdButton: {
         alignItems: 'flex-start',
         justifyContent: 'center',
         backgroundColor: colors.transparent,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderTopLeftRadius: BaseStyles.BorderRadius.small,
-        borderBottomLeftRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
+        borderBottomWidth: 1,
         borderColor: colors.lightGray,
-        height: 40,
+        height: 30,
     },
     unselectedMiddleThirdButton: {
         alignItems: 'center',
         justifyContent: 'center',
         backgroundColor: colors.transparent,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderWidth: 1,
+        borderBottomWidth: 1,
         borderColor: colors.lightGray,
-        height: 40,
+        height: 30,
+        marginHorizontal: BaseStyles.MarginPadding.statusButton,
     },
     unselectedRightThirdButton: {
         alignItems: 'flex-end',
         justifyContent: 'center',
         backgroundColor: colors.transparent,
-        padding: BaseStyles.MarginPadding.mediumConst,
         width: BaseStyles.ContentWidth.almostThird,
-        borderTopRightRadius: BaseStyles.BorderRadius.small,
-        borderBottomRightRadius: BaseStyles.BorderRadius.small,
-        borderWidth: 1,
+        borderBottomWidth: 1,
         borderColor: colors.lightGray,
-        height: 40,
+        height: 30,
     },
     unselectedText: {
-        color: colors.lightGray,
-        fontSize: BaseStyles.FontTheme.reg,
+        color: colors.darkGray,
+        fontSize: BaseStyles.FontTheme.small - 1,
         alignSelf: 'center',
     },
     underline: {
-        borderBottomWidth: 2, 
+        borderBottomWidth: 2,
     },
 });
 
 const serviceRequestStrings = strings.serviceRequestPage;
+
+const initialRadioState: ServiceRequestState = {
+    currentRequestsSelected: true,
+    requestSelected: ServiceRequestStatusEnums.Pending,
+    serviceRequests: [],
+    pending: 0,
+    scheduled: 0,
+    inProgress: 0,
+    completed: 0,
+    canceled: 0,
+    declined: 0,
+};
 
 function filterTabbedObjects(unfilteredServiceRequests: ServiceRequest[], requestStatus: ServiceRequestStatus) {
     const filteredServiceRequests: ServiceRequest[] = unfilteredServiceRequests.filter(sr => sr.status === requestStatus);
@@ -239,7 +217,6 @@ function filterTabbedObjects(unfilteredServiceRequests: ServiceRequest[], reques
  */
 
 export class ServiceRequestScreenBase extends React.Component<ServiceRequestScreenProps, ServiceRequestState>{
-    tabs = ["PENDING", "SCHEDULED", "IN_PROGRESS"];
 
     currentServiceRequests;
 
@@ -251,6 +228,7 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
 
     constructor(props: Readonly<ServiceRequestScreenProps>) {
         super(props);
+        this.state = initialRadioState;
 
         this.onPressInactiveRequests = this.onPressInactiveRequests.bind(this);
         this.onPressActiveRequests = this.onPressActiveRequests.bind(this);
@@ -269,20 +247,19 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
         this.renderFilteredServiceRequests = this.renderFilteredServiceRequests.bind(this);
         this.render = this.render.bind(this);
 
-        this.state = { currentRequestsSelected: true, requestSelected: ServiceRequestStatusEnums.Pending, serviceRequests: [] };
         props.parentCallBack(ServiceRequestCompletionStatus.Current);
         props.parentCallBack2(ServiceRequestStatusEnums.Pending);
 
     }
 
-    componentDidMount(){
+    componentDidMount() {
         // When the component is mounted, update the header. This component can be navigated from a different stack so 
         // we need to make sure the header remains updated in the case this happens
-        const {onUpdateHeader} = this.props;
+        const { onUpdateHeader } = this.props;
         onUpdateHeader(MainAppStack[1]);
     }
 
-    componentWillUnmount(){
+    componentWillUnmount() {
         this.setState({
             serviceRequests: [],
         });
@@ -345,15 +322,26 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
         navigation.navigate(navigationPages.ServiceRequestModal, { serviceRequest }, true);
     }
 
-    async callFetchServiceRequests(propId: string){
-        await fetchServiceRequests(propId).then(response =>{
-            const {data} = response;
-            const {reqs} = data;
+    async callFetchServiceRequests(propId: string) {
+        await fetchServiceRequests(propId).then(response => {
+            const { data } = response;
+            const { reqs } = data;
 
-            let serviceRequests : ServiceRequest[] = [];
+            // set initial state- this guarantees that the state gets updated for the requests even if a given property has no requests
+            this.setState({ serviceRequests: [] });
+            this.setState({ pending: 0, scheduled: 0, inProgress: 0, completed: 0, canceled: 0, declined: 0 });
+
+            let pending: number = 0;
+            let scheduled: number = 0;
+            let inProgress: number = 0;
+            let completed: number = 0;
+            let canceled: number = 0;
+            let declined: number = 0;
+
+            const serviceRequests: ServiceRequest[] = [];
 
             reqs.forEach(req => {
-                const {appFixed, location, serviceDate, status, client, serviceCompany, serviceCategory, details } = req;
+                const { appFixed, location, serviceDate, status, client, serviceCompany, serviceCategory, details } = req;
                 const appliance = {
                     applianceId: appFixed.appId,
                     category: stringToCategory(appFixed.category),
@@ -363,32 +351,57 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
                     serialNum: appFixed.serialNum,
                     location: appFixed.location,
                 };
-
                 const serviceRequest: ServiceRequest = {
                     address: location,
                     startDate: serviceDate,
                     companyName: serviceCompany,
                     details,
                     appliance,
-                    status : ServiceRequestStatusEnums[status],
+                    status: ServiceRequestStatusEnums[status],
                 };
 
                 serviceRequests.push(serviceRequest);
+
+                switch (ServiceRequestStatusEnums[status]) {
+                    case ServiceRequestStatusEnums.Scheduled:
+                        scheduled += 1;
+                        break;
+                    case ServiceRequestStatusEnums.InProgress:
+                        inProgress += 1;
+                        break;
+                    case ServiceRequestStatusEnums.Pending:
+                        pending += 1;
+                        break;
+                    case ServiceRequestStatusEnums.Completed:
+                        completed += 1;
+                        break;
+                    case ServiceRequestStatusEnums.Canceled:
+                        canceled += 1;
+                        break;
+                    case ServiceRequestStatusEnums.Declined:
+                        declined += 1;
+                        break;
+                    default:
+                        break;
+                }
+
+                this.setState({ pending, scheduled, inProgress, completed, canceled, declined });
             });
-            this.setState({serviceRequests});  
+
+            this.setState({ serviceRequests });
         }).catch(error => {
             console.log(error);
         });
     }
 
 
-    renderServiceRequestButtons(){
-        const {serviceRequests} = this.state;
+    renderServiceRequestButtons() {
+        const { serviceRequests } = this.state;
         return (
             <>
-            {serviceRequests.forEach(request => {
-                return (<ServiceRequestButton serviceRequest={request} />);
-            })}
+                {serviceRequests.forEach(request => {
+                    return (<ServiceRequestButton serviceRequest={request} />);
+                })}
             </>
         );
     }
@@ -400,34 +413,34 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
     }
 
     renderCompletionStatusRadioButton(currentRequestsSelected: boolean) {
-        const leftButtonStyle = currentRequestsSelected ? styles.selectedLeftButton : styles.unselectedLeftButton;
-        const rightButtonStyle = currentRequestsSelected ? styles.unselectedRightButton : styles.selectedRightButton;
         return (
-            <>
-                <View style={styles.container}>
-                    <View style={styles.buttonContainer}>
-                        <TouchableOpacity
-                            testID='service-radio-current'
-                            style={leftButtonStyle}
-                            onPress={this.onPressActiveRequests}>
-                            <Text style={currentRequestsSelected ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabA}
-                            </Text>
-                        </TouchableOpacity>
+            currentRequestsSelected ?
+                <>
+                    <View style={{ alignItems: 'center' }}>
                         <TouchableOpacity
                             testID='service-radio-completed'
-                            style={rightButtonStyle}
+                            style={styles.archivedButtonStyle}
                             onPress={this.onPressInactiveRequests}>
-                            <Text style={currentRequestsSelected ?
-                                styles.unselectedText : styles.selectedText}>
+                            <Text style={styles.currentArchivedButtonText}>
                                 {serviceRequestStrings.tabB}
 
                             </Text>
                         </TouchableOpacity>
                     </View>
-                </View>
-            </>
+                </>
+                :
+                <>
+                    <View style={{ alignItems: 'center' }}>
+                        <TouchableOpacity
+                            testID='service-radio-current'
+                            style={styles.currentButtonStyle}
+                            onPress={this.onPressActiveRequests}>
+                            <Text style={styles.currentArchivedButtonText}>
+                                {serviceRequestStrings.tabA}
+                            </Text>
+                        </TouchableOpacity>
+                    </View>
+                </>
         );
     }
 
@@ -435,40 +448,39 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
         const leftThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.Pending) ? styles.selectedLeftThirdButton : styles.unselectedLeftThirdButton;
         const middleThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.Scheduled) ? styles.selectedMiddleThirdButton : styles.unselectedMiddleThirdButton;
         const rightThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.InProgress) ? styles.selectedRightThirdButton : styles.unselectedRightThirdButton;
+        const { pending, scheduled, inProgress } = this.state;
+
         return (
             <>
-                <View style={styles.container}>
-                    <View style={styles.buttonContainer}>
-                        <TouchableOpacity
-                            testID='service-radio-pending'
-                            style={leftThirdButtonStyle}
-                            onPress={this.onPressPendingRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.Pending) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabA1}
-                            </Text>
-                            <View style={styles.underline}/>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                            testID='service-radio-scheduled'
-                            style={middleThirdButtonStyle}
-                            onPress={this.onPressScheduledRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.Scheduled) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabA2}
-                            </Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                            testID='service-radio-inprogress'
-                            style={rightThirdButtonStyle}
-                            onPress={this.onPressInProgressRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.InProgress) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabA3}
+                <View style={styles.buttonContainer}>
+                    <TouchableOpacity
+                        testID='service-radio-pending'
+                        style={leftThirdButtonStyle}
+                        onPress={this.onPressPendingRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.Pending) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabA1}(${pending})`}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        testID='service-radio-scheduled'
+                        style={middleThirdButtonStyle}
+                        onPress={this.onPressScheduledRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.Scheduled) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabA2}(${scheduled})`}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        testID='service-radio-inprogress'
+                        style={rightThirdButtonStyle}
+                        onPress={this.onPressInProgressRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.InProgress) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabA3}(${inProgress})`}
 
-                            </Text>
-                        </TouchableOpacity>
-                    </View>
+                        </Text>
+                    </TouchableOpacity>
                 </View>
             </>
         );
@@ -478,75 +490,69 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
         const leftThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.Completed) ? styles.selectedLeftThirdButton : styles.unselectedLeftThirdButton;
         const middleThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.Canceled) ? styles.selectedMiddleThirdButton : styles.unselectedMiddleThirdButton;
         const rightThirdButtonStyle = (requestsSelected === ServiceRequestStatusEnums.Declined) ? styles.selectedRightThirdButton : styles.unselectedRightThirdButton;
-        
+        const { completed, canceled, declined } = this.state;
+
         return (
             <>
-                <View style={styles.container}>
-                    <View style={styles.buttonContainer}>
-                        <TouchableOpacity
-                            testID='service-radio-completed'
-                            style={leftThirdButtonStyle}
-                            onPress={this.onPressCompletedRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.Completed) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabB1}
-                            </Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                            testID='service-radio-canceled'
-                            style={middleThirdButtonStyle}
-                            onPress={this.onPressCanceledRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.Canceled) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabB2}
+                <View style={styles.buttonContainer}>
+                    <TouchableOpacity
+                        testID='service-radio-completed'
+                        style={leftThirdButtonStyle}
+                        onPress={this.onPressCompletedRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.Completed) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabB1}(${completed})`}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        testID='service-radio-canceled'
+                        style={middleThirdButtonStyle}
+                        onPress={this.onPressCanceledRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.Canceled) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabB2}(${canceled})`}
 
-                            </Text>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                            testID='service-radio-declined'
-                            style={rightThirdButtonStyle}
-                            onPress={this.onPressDeclinedRequests}>
-                            <Text style={(requestsSelected === ServiceRequestStatusEnums.Declined) ?
-                                styles.selectedText : styles.unselectedText}>
-                                {serviceRequestStrings.tabB3}
+                        </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                        testID='service-radio-declined'
+                        style={rightThirdButtonStyle}
+                        onPress={this.onPressDeclinedRequests}>
+                        <Text style={(requestsSelected === ServiceRequestStatusEnums.Declined) ?
+                            styles.selectedText : styles.unselectedText}>
+                            {`${serviceRequestStrings.tabB3}(${declined})`}
 
-                            </Text>
-                        </TouchableOpacity>
-                    </View>
+                        </Text>
+                    </TouchableOpacity>
                 </View>
             </>
         );
     }
 
     renderServiceRequests() {
-        const {properties} = this.props;
+        const { properties } = this.props;
         const { currentRequestsSelected, requestSelected, serviceRequests } = this.state;
 
         return (
             <>
-                <ServiceRequestAddressPanel properties={properties} parentCallBack={async (propId: string)  => {await this.callFetchServiceRequests(propId);}}/>
-                <View style ={{maxWidth: 458, width: '95%', alignSelf: 'center', marginTop: 10} /** TODO: Update these styles so it renders properly on all devices*/}>
-                    <SearchForm<ServiceRequest>  
-                        objects={serviceRequests} 
-                        parentCallBack={() => {} /**TODO: Insert Your Service Requests Set State Function Here!!! */} 
-                        placeholder="Search requests..." 
-                        trim/>
+                <View style={{ marginTop: 30, width: BaseStyles.ContentWidth.reg, alignSelf: 'center', paddingHorizontal: 3 } /* Styled to be the same width as the SearchForm */}>
+                    <ServiceRequestAddressPanel properties={properties} parentCallBack={async (propId: string) => { await this.callFetchServiceRequests(propId); }} />
+                </View>
+                <View style={{ width: BaseStyles.ContentWidth.reg, alignSelf: 'center', marginTop: 10, height: 50 } /* TODO: Update these styles so it renders properly on all devices */}>
+                    <SearchForm<ServiceRequest>
+                        objects={serviceRequests}
+                        parentCallBack={() => { } /* TODO: Insert Your Service Requests Set State Function Here!!! */}
+                        placeholder="Search requests..."
+                        trim />
                     {/** TODO: Add Panel Here. */}
                 </View>
-
-                <>
-                    {this.renderCompletionStatusRadioButton(currentRequestsSelected)}
-                </>
-                <>
-                    <>
-                        {currentRequestsSelected ? this.renderActive(requestSelected) : this.renderInactive(requestSelected)}
-                    </>
-                </>
-                <>
-                    <>
-                        { this.renderFilteredServiceRequests() }
-                    </>
-                </>
+                {this.renderCompletionStatusRadioButton(currentRequestsSelected)}
+                <View style={{ width: '100%', alignSelf: 'center', justifyContent: 'center', alignItems: 'center', paddingTop: BaseStyles.MarginPadding.medium }}>
+                    {currentRequestsSelected ? this.renderActive(requestSelected) : this.renderInactive(requestSelected)}
+                </View>
+                <View style={{ justifyContent: 'center' }}>
+                    {this.renderFilteredServiceRequests()}
+                </View>
             </>
         );
     }
@@ -565,14 +571,14 @@ export class ServiceRequestScreenBase extends React.Component<ServiceRequestScre
 
         return (
             <>
-            {filteredServiceRequests.map(
-                serviceRequest => {
-                    const {appliance} = serviceRequest;
-                    const {applianceId} = appliance;
-                    return (<ServiceRequestButton key={applianceId} onClick={this.openServiceRequestModal} serviceRequest={serviceRequest} />);
-                })}
+                {filteredServiceRequests.map(
+                    serviceRequest => {
+                        const { appliance } = serviceRequest;
+                        const { applianceId } = appliance;
+                        return (<ServiceRequestButton key={applianceId} onClick={this.openServiceRequestModal} serviceRequest={serviceRequest} />);
+                    })}
             </>
-            );
+        );
     }
 
     render() {

--- a/homepairs/homepairsUI/src/state/types.ts
+++ b/homepairs/homepairsUI/src/state/types.ts
@@ -209,7 +209,7 @@ export type ServiceProvider = {
 
 export enum ServiceRequestCompletionStatus {
     Current = 'Current',
-    Completed = 'Completed',
+    Archived = 'Archived',
 }
 
 export enum ServiceRequestStatusEnums {


### PR DESCRIPTION
- aligned search + dropdown bar to be the same width
       (this took me a lot longer than I'd thought since search form is an input form and had its own 
        horizontal padding, so I accounted for that)
- button ui fully updated for service request statuses, including numbering
       (I'm like 80% sure alex told us a while back I think to not do the ACTIVE text, but I'm not 100%)
- fixed request state issues Cesar found 
       (basically, needed to declare initial values to 0 and empty)

<img width="545" alt="Screen Shot 2020-05-21 at 6 17 20 AM" src="https://user-images.githubusercontent.com/15078566/82562775-c7214700-9b2a-11ea-9c28-c0af900cc1c0.png">

